### PR TITLE
feat: inversion benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,7 @@ harness = false
 [[bench]]
 name = "mul_assign"
 harness = false
+
+[[bench]]
+name = "invert"
+harness = false

--- a/benches/invert.rs
+++ b/benches/invert.rs
@@ -58,7 +58,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             "invert | lambdaworks-math - lambdaclass/lambdaworks@61b26ab",
             |b| {
                 b.iter(|| {
-                    black_box((&num).inv());
+                    black_box(num.inv());
                 });
             },
         );

--- a/benches/invert.rs
+++ b/benches/invert.rs
@@ -1,0 +1,69 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // starknet-ff
+    {
+        use starknet_ff::FieldElement;
+
+        let num = FieldElement::from_hex_be(
+            "0x03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
+        )
+        .unwrap();
+
+        c.bench_function(
+            "invert | starknet-ff - xJonathanLEI/starknet-rs@a6cbfa3",
+            |b| {
+                b.iter(|| {
+                    black_box(num.invert().unwrap());
+                });
+            },
+        );
+    }
+
+    // cairo-felt - no invert method available
+
+    // stark_curve
+    {
+        use stark_curve::ff::Field;
+        use stark_curve::FieldElement;
+        use stark_hash::Felt;
+
+        let num = FieldElement::from(
+            Felt::from_be_slice(
+                &hex::decode("03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb")
+                    .unwrap(),
+            )
+            .unwrap(),
+        );
+
+        c.bench_function("invert | stark_curve - eqlabs/pathfinder@fccef91", |b| {
+            b.iter(|| {
+                black_box(num.invert().unwrap());
+            });
+        });
+    }
+
+    // lambdaworks-math
+    {
+        use lambdaworks_math::field::{
+            element::FieldElement, fields::fft_friendly::stark_252_prime_field::Stark252PrimeField,
+        };
+
+        let num = FieldElement::<Stark252PrimeField>::from_hex(
+            "03d937c035c878245caf64531a5756109c53068da139362728feb561405371cb",
+        )
+        .unwrap();
+
+        c.bench_function(
+            "invert | lambdaworks-math - lambdaclass/lambdaworks@61b26ab",
+            |b| {
+                b.iter(|| {
+                    black_box((&num).inv());
+                });
+            },
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
This PR adds a benchmark for felt inversion.

I couldn't find such an operation for `cairo-felt` 🤷