### PR TITLE
enable lto, O3 and codegen-units=1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,8 @@ harness = false
 [[bench]]
 name = "invert"
 harness = false
+
+[profile.bench]
+lto = true
+opt-level = 3
+codegen-units = 1


### PR DESCRIPTION
Since these libraries will end up in production environments, enabling all the common optimizations when running the benchmarks makes sense. So this PR makes just that. It enables LTO, opt-level 3 and codegen-units=1. We can also enable some more for CPU-specific optimizations. 
More information here: https://nnethercote.github.io/perf-book/build-configuration.html