### PR TITLE
fix: hide benchmark arguments with black_box

### DIFF
--- a/benches/add.rs
+++ b/benches/add.rs
@@ -20,7 +20,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             "add | starknet-ff - xJonathanLEI/starknet-rs@a6cbfa3",
             |b| {
                 b.iter(|| {
-                    black_box(num_1.add(num_2));
+                    black_box(black_box(num_1).add(black_box(num_2)));
                 });
             },
         );
@@ -43,7 +43,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 // No choice but to clone here. See the `add_assign` bench for the clone-less
                 // version
-                black_box(num_1.clone().add(&num_2));
+                black_box(black_box(num_1.clone()).add(black_box(&num_2)));
             });
         });
     }
@@ -70,7 +70,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function("add | stark_curve - eqlabs/pathfinder@fccef91", |b| {
             b.iter(|| {
-                black_box(num_1.add(num_2));
+                black_box(black_box(num_1).add(black_box(num_2)));
             });
         });
     }
@@ -94,7 +94,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             "add | lambdaworks-math - lambdaclass/lambdaworks@75423a1",
             |b| {
                 b.iter(|| {
-                    black_box((&num_1).add(&num_2));
+                    black_box(black_box(&num_1).add(black_box(&num_2)));
                 });
             },
         );

--- a/benches/add_assign.rs
+++ b/benches/add_assign.rs
@@ -21,7 +21,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     #[allow(clippy::unit_arg)]
-                    black_box(num_1.add_assign(num_2));
+                    black_box(num_1.add_assign(black_box(num_2)));
                 });
             },
         );
@@ -45,7 +45,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     #[allow(clippy::unit_arg)]
-                    black_box(num_1.add_assign(&num_2));
+                    black_box(num_1.add_assign(black_box(&num_2)));
                 });
             },
         );
@@ -76,7 +76,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     #[allow(clippy::unit_arg)]
-                    black_box(num_1.add_assign(&num_2));
+                    black_box(num_1.add_assign(black_box(&num_2)));
                 });
             },
         );
@@ -104,7 +104,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     // We have to clone here as `FieldElement` from lambdaworks-math does not
                     // implement `AddAssign<&FieldElement>`.
                     #[allow(clippy::unit_arg)]
-                    black_box(num_1.add_assign(num_2.clone()));
+                    black_box(num_1.add_assign(black_box(num_2.clone())));
                 });
             },
         );

--- a/benches/invert.rs
+++ b/benches/invert.rs
@@ -14,7 +14,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             "invert | starknet-ff - xJonathanLEI/starknet-rs@a6cbfa3",
             |b| {
                 b.iter(|| {
-                    black_box(num.invert().unwrap());
+                    black_box(black_box(&num).invert().unwrap());
                 });
             },
         );
@@ -38,7 +38,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function("invert | stark_curve - eqlabs/pathfinder@fccef91", |b| {
             b.iter(|| {
-                black_box(num.invert().unwrap());
+                black_box(black_box(&num).invert().unwrap());
             });
         });
     }
@@ -58,7 +58,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             "invert | lambdaworks-math - lambdaclass/lambdaworks@75423a1",
             |b| {
                 b.iter(|| {
-                    black_box(num.inv());
+                    black_box(black_box(&num).inv());
                 });
             },
         );

--- a/benches/mul.rs
+++ b/benches/mul.rs
@@ -20,7 +20,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             "mul | starknet-ff - xJonathanLEI/starknet-rs@a6cbfa3",
             |b| {
                 b.iter(|| {
-                    black_box(num_1.mul(num_2));
+                    black_box(black_box(&num_1).mul(black_box(num_2)));
                 });
             },
         );
@@ -43,7 +43,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 // No choice but to clone here. See the `sub_assign` bench for the clone-less
                 // version
-                black_box(num_1.clone().mul(&num_2));
+                black_box(black_box(&num_1).mul(black_box(&num_2)));
             });
         });
     }
@@ -70,7 +70,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function("mul | stark_curve - eqlabs/pathfinder@fccef91", |b| {
             b.iter(|| {
-                black_box(num_1.mul(num_2));
+                black_box(black_box(num_1).mul(black_box(num_2)));
             });
         });
     }
@@ -94,7 +94,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             "mul | lambdaworks-math - lambdaclass/lambdaworks@75423a1",
             |b| {
                 b.iter(|| {
-                    black_box((&num_1).mul(&num_2));
+                    black_box(black_box(&num_1).mul(black_box(&num_2)));
                 });
             },
         );

--- a/benches/mul_assign.rs
+++ b/benches/mul_assign.rs
@@ -21,7 +21,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     #[allow(clippy::unit_arg)]
-                    black_box(num_1.mul_assign(num_2));
+                    black_box(num_1.mul_assign(black_box(num_2)));
                 });
             },
         );
@@ -45,7 +45,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     #[allow(clippy::unit_arg)]
-                    black_box(num_1.mul_assign(&num_2));
+                    black_box(num_1.mul_assign(black_box(&num_2)));
                 });
             },
         );
@@ -76,7 +76,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     #[allow(clippy::unit_arg)]
-                    black_box(num_1.mul_assign(&num_2));
+                    black_box(num_1.mul_assign(black_box(&num_2)));
                 });
             },
         );

--- a/benches/sub.rs
+++ b/benches/sub.rs
@@ -20,7 +20,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             "sub | starknet-ff - xJonathanLEI/starknet-rs@a6cbfa3",
             |b| {
                 b.iter(|| {
-                    black_box(num_1.sub(num_2));
+                    black_box(black_box(num_1).sub(black_box(num_2)));
                 });
             },
         );
@@ -43,7 +43,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 // No choice but to clone here. See the `sub_assign` bench for the clone-less
                 // version
-                black_box(num_1.clone().sub(&num_2));
+                black_box(black_box(&num_1).sub(black_box(&num_2)));
             });
         });
     }
@@ -70,7 +70,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         c.bench_function("sub | stark_curve - eqlabs/pathfinder@fccef91", |b| {
             b.iter(|| {
-                black_box(num_1.sub(num_2));
+                black_box(black_box(num_1).sub(black_box(num_2)));
             });
         });
     }
@@ -94,7 +94,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             "sub | lambdaworks-math - lambdaclass/lambdaworks@75423a1",
             |b| {
                 b.iter(|| {
-                    black_box((&num_1).sub(&num_2));
+                    black_box(black_box(&num_1).sub(black_box(&num_2)));
                 });
             },
         );

--- a/benches/sub_assign.rs
+++ b/benches/sub_assign.rs
@@ -21,7 +21,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     #[allow(clippy::unit_arg)]
-                    black_box(num_1.sub_assign(num_2));
+                    black_box(num_1.sub_assign(black_box(num_2)));
                 });
             },
         );
@@ -45,7 +45,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     #[allow(clippy::unit_arg)]
-                    black_box(num_1.sub_assign(&num_2));
+                    black_box(num_1.sub_assign(black_box(&num_2)));
                 });
             },
         );
@@ -76,7 +76,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     #[allow(clippy::unit_arg)]
-                    black_box(num_1.sub_assign(&num_2));
+                    black_box(num_1.sub_assign(black_box(&num_2)));
                 });
             },
         );


### PR DESCRIPTION
Lack of black-boxing in benchmark arguments combined with them being constants was causing excessive constant propagation in some benchmarks, leading to unrepresentative results.
With the exception of `rhs` in `*_assign`, all arguments are now hidden behind a `black_box`. The exception is there because otherwise the benchmark code would cause clones and copies that could distort the actual benchmark.
